### PR TITLE
Atribute based XSS fixed on components and applications views

### DIFF
--- a/src/main/webapp/WEB-INF/views/applications.jsp
+++ b/src/main/webapp/WEB-INF/views/applications.jsp
@@ -63,7 +63,7 @@
                             <a data-toggle="modal" data-id="${application.id}" class="open-AddApplicationVersionModal btn" href="#addApplicationVersionModal"><spring:message code="label.version.add"/></a>
                             </shiro:hasPermission>
                             <shiro:hasPermission name="${updateApplication}">
-                            <a data-toggle="modal" data-id="${application.id}" data-name="${application.name}" class="open-EditApplicationModal btn" href="#editApplicationModal"><spring:message code="label.edit"/></a>
+                            <a data-toggle="modal" data-id="${application.id}" data-name="${e:forHtmlAttribute(application.name)}" class="open-EditApplicationModal btn" href="#editApplicationModal"><spring:message code="label.edit"/></a>
                             </shiro:hasPermission>
                         </div>
 

--- a/src/main/webapp/WEB-INF/views/libraries.jsp
+++ b/src/main/webapp/WEB-INF/views/libraries.jsp
@@ -28,7 +28,7 @@
                     <td><e:forHtmlContent value="${libList.library.libraryVendor.vendor}"/></td>
                     <td><e:forHtmlContent value="${libList.library.libraryname}"/></td>
                     <td><e:forHtmlContent value="${libList.libraryversion}"/></td>
-                    <td><a data-toggle="modal" class="open-LicenseLibrariesModal" data-licensefiletype ="${libList.library.license.contenttype}" data-licenseid ="${libList.library.license.id}" data-licensename ="${libList.library.license.licensename}" data-licensfileename ="${libList.library.license.filename}" href="#licenseLibrariesModal"><e:forHtmlContent value="${libList.library.license.licensename}"/></a></td>
+                    <td><a data-toggle="modal" class="open-LicenseLibrariesModal" data-licensefiletype ="${libList.library.license.contenttype}" data-licenseid ="${libList.library.license.id}" data-licensename ="${e:forHtmlAttribute(libList.library.license.licensename)}" data-licensfileename ="${libList.library.license.filename}" href="#licenseLibrariesModal"><e:forHtmlContent value="${libList.library.license.licensename}"/></a></td>
                     <td><e:forHtmlContent value="${libList.library.language}"/></td>
                     <shiro:hasPermission name="${updatelibrary}">
                     <td style="vertical-align:top;text-align:right;">
@@ -38,11 +38,11 @@
                                data-vendorid ="${libList.library.libraryVendor.id}"
                                data-licenseid ="${libList.library.license.id}"
                                data-libraryversionid ="${libList.id}"
-                               data-vendor ="${libList.library.libraryVendor.vendor}"
-                               data-libraryname ="${libList.library.libraryname}"
-                               data-libraryversion ="${libList.libraryversion}"
-                               data-licensename ="${libList.library.license.licensename}"
-                               data-language ="${libList.library.language}"
+                               data-vendor ="${e:forHtmlAttribute(libList.library.libraryVendor.vendor)}"
+                               data-libraryname ="${e:forHtmlAttribute(libList.library.libraryname)}"
+                               data-libraryversion ="${e:forHtmlAttribute(libList.libraryversion)}"
+                               data-licensename ="${e:forHtmlAttribute(libList.library.license.licensename)}"
+                               data-language ="${e:forHtmlAttribute(libList.library.language)}"
                                class="open-EditLibrariesModal btn" href="#editLibrariesModal">Edit</a>
                         </div>
                     </td>
@@ -104,7 +104,7 @@
                         <select id="licenseids" name="license"  class="licenseidsclass">
                             <option value="">--</option>
                             <c:forEach items="${uniquelicList}" var="libList">
-                                <option value="${libList.licensename}"><e:forHtmlContent value="${libList.licensename}"/></option>
+                                <option value="${e:forHtmlAttribute(libList.licensename)}"><e:forHtmlContent value="${libList.licensename}"/></option>
                             </c:forEach>
                         </select>
                             </c:if>
@@ -123,7 +123,7 @@
                         <select id="languageid" name="language"  class="languageidclass">
                             <option value="">--</option>
                             <c:forEach items="${uniqueLang}" var="libList">
-                                <option value="${libList}"><e:forHtmlContent value="${libList}"/></option>
+                                <option value="${e:forHtmlAttribute(libList)}"><e:forHtmlContent value="${libList}"/></option>
                             </c:forEach>
                         </select>
                         <input id="language" name ="languagesel"  type="text" required="required" style="  position:relative; height: 20px; border: 0; left: -223px; width: 183px;" />
@@ -176,7 +176,7 @@
                                 <select id="licenseeditids" name="license">
                                     <option value="">--</option>
                                     <c:forEach items="${uniquelicList}" var="libList">
-                                        <option value="${libList.licensename}"><e:forHtmlContent value="${libList.licensename}"/></option>
+                                        <option value=<e:forHtmlAttribute value="${libList.licensename}"/>><e:forHtmlContent value="${libList.licensename}"/></option>
                                     </c:forEach>
                                 </select>
                             </div>

--- a/src/main/webapp/WEB-INF/views/libraries.jsp
+++ b/src/main/webapp/WEB-INF/views/libraries.jsp
@@ -176,7 +176,7 @@
                                 <select id="licenseeditids" name="license">
                                     <option value="">--</option>
                                     <c:forEach items="${uniquelicList}" var="libList">
-                                        <option value=<e:forHtmlAttribute value="${libList.licensename}"/>><e:forHtmlContent value="${libList.licensename}"/></option>
+                                        <option value="${e:forHtmlAttribute(libList.licensename)}"><e:forHtmlContent value="${libList.licensename}"/></option>
                                     </c:forEach>
                                 </select>
                             </div>


### PR DESCRIPTION
It was possible to perform an atribute based cross site scripting attack. 
The code was already protecting XSS attacks on HTML context, so it was not possible to exploit an XSS by setting the component or application name with the following payload:
```javascript
<script>alert(1)</script>
```
However, the code was also reflected on several attributes of the Edit button, and on some option tags. One of the possible payloads for exploiting this new XSS is:
```javascript
"onmouseover="alert(1)
```
Now, XSS cannot be performed on these fields:
* Application name
* Vendor
* Component name
* Component version
* License
* Language