### PR TITLE
enable HEAD method and add Last-Modified header

### DIFF
--- a/src/main/java/org/owasp/dependencytrack/controller/DownloadController.java
+++ b/src/main/java/org/owasp/dependencytrack/controller/DownloadController.java
@@ -83,7 +83,7 @@ public class DownloadController extends AbstractController {
      * @param filename the xml file to download
      * @throws java.io.IOException bad robot
      */
-    @RequestMapping(value = "/nist/{filename:.+}", method = RequestMethod.GET)
+    @RequestMapping(value = "/nist/{filename:.+}", method = {RequestMethod.GET, RequestMethod.HEAD})
     public void getNistFile(HttpServletResponse response,
                             @PathVariable("filename") String filename) throws IOException {
         final File canonicalizedFile = new File(filename).getCanonicalFile();
@@ -93,12 +93,14 @@ public class DownloadController extends AbstractController {
         InputStream fis = null;
         OutputStream out = null;
         try {
-            fis = new FileInputStream(Constants.NIST_DIR + File.separator + filename);
+            File file = new File(Constants.NIST_DIR + File.separator + filename);
+            fis = new FileInputStream(file);
             if (filename.endsWith(".gz")) {
                 response.setHeader("Content-Type", "application/x-gzip;");
             } else if (filename.endsWith(".xml")) {
                 response.setHeader("Content-Type", "application/xml;");
             }
+            response.addDateHeader("Last-Modified", file.lastModified());
             out = response.getOutputStream();
             IOUtils.copy(fis, out);
             out.flush();


### PR DESCRIPTION
required for dependency-check-maven plugin to be able to use custom cve cache - cveUrl properties