### PR TITLE
Specifies how to map the user identifier entered by the user to that passed through to LDAP

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -116,6 +116,18 @@ alpine.ldap.bind.username=
 alpine.ldap.bind.password=
 
 # Optional
+# Specifies how to map the user identifier entered by the user to that passed through to LDAP.
+# If is configured to a non-empty value, the substring %s in this value will be replaced
+# with the entered username.
+# The recommended format of this value depends on your LDAP server(Active Directory, OpenLDAP, etc.).
+# Examples:
+#	 *   alpine.ldap.auth.username.format=%s
+#	 * 	 alpine.ldap.auth.username.format=%s@example.com
+#	 *   alpine.ldap.auth.username.format=uid=%s,ou=People,dc=example,dc=com
+#	 *   alpine.ldap.auth.username.format=userPrincipalName=%s,ou=People,dc=example,dc=com
+alpine.ldap.auth.username.format=
+
+# Optional
 # Specifies the Attribute that all queries should use
 # The default attribute is userPrincipalName
 alpine.ldap.attribute.name=


### PR DESCRIPTION
Added an optional LDAP configuration improvement needed for some type of servers.

Specifies how to map the username identifier entered by the user to that passed through to LDAP.
If is configured to a non-empty value, the substring %s in this value will be replaced with the entered username.
The recommended format of this value depends on your LDAP server(Active Directory, OpenLDAP, etc.).
Examples:
alpine.ldap.auth.username.format=%s
alpine.ldap.auth.username.format=%s@example.com
alpine.ldap.auth.username.format=uid=%s,ou=People,dc=example,dc=com
alpine.ldap.auth.username.format=userPrincipalName=%s,ou=People,dc=example,dc=com